### PR TITLE
Temporary cert gen to separate deploy folder

### DIFF
--- a/ad_manager/templates/ad_manager/isd_detail.html
+++ b/ad_manager/templates/ad_manager/isd_detail.html
@@ -49,9 +49,9 @@
   </div>
 
   <br/>
+  <br/>
   <div>
       Select the .topo file you want to use to create the trc for this ISD.
-      <span class="text-danger">WARNING: This overwrites you main scion gen folder.</span><br/>
       <span class="text-success">You are currently using the following certificate file: </span>
       <span id="certfileName">no file</span>
       <form class="form-inline" method="POST" enctype="multipart/form-data" action="{% url 'upload_file_ref' %}">

--- a/ad_manager/views.py
+++ b/ad_manager/views.py
@@ -776,7 +776,11 @@ def create_global_gen(topo_path):
     # ./scion.sh topology -c '/../scion/topology/Switzerland.topo'
     # we reuse the generation facility provided by scion.sh
     scion_sh_path = os.path.join(PROJECT_ROOT, 'scion.sh')
-    result = subprocess.check_call([scion_sh_path, 'topology', '-c', topo_path],
+    result = subprocess.check_call([scion_sh_path, 'topology',
+                                    '-c', topo_path,
+                                    '-o', os.path.join(PROJECT_ROOT,
+                                                       'deploy-gen')
+                                    ],
                                    cwd=PROJECT_ROOT)
     return result
 
@@ -850,7 +854,7 @@ def create_local_gen(isd_as, tp):
 
     dispatcher_folder_path = os.path.join(local_gen_path, 'dispatcher')
     if not os.path.exists(dispatcher_folder_path):
-        copytree(os.path.join(PROJECT_ROOT, 'gen', 'dispatcher'),
+        copytree(os.path.join(PROJECT_ROOT, 'deploy-gen', 'dispatcher'),
                  dispatcher_folder_path)
 
     # TODO: Cert distribution needs integration with scion-coord,
@@ -862,7 +866,8 @@ def create_local_gen(isd_as, tp):
     rmtree(os.path.join(shared_files_path), True)  # rm shared_files & content
     # populate the shared_files folder with the relevant files for this AS
     certgen_path = os.path.join(PROJECT_ROOT,
-                                'gen/ISD{}/AS{}/endhost/'.format(isd_id, as_id))
+                                'deploy-gen/ISD{}/AS{}/endhost/'.format(isd_id,
+                                                                        as_id))
     copytree(certgen_path, shared_files_path)
     # remove files that are not shared
     try:


### PR DESCRIPTION
The temporary certificate generation procedure now uses a separate gen folder to avoid clashes with local host tests

This closes issue #22

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion-web/24)
<!-- Reviewable:end -->
