### PR TITLE
Fix blank topology input IP address 

### DIFF
--- a/ad_manager/static/js/topology_input.js
+++ b/ad_manager/static/js/topology_input.js
@@ -279,12 +279,14 @@ function gatherIPsforCloudEngines() {
     var ipList = [];
     var parent = $('.cloudEngineItemList');
 
-    $(".server-address-input").each(function () {
+    $(".server-address-input").each(function() {
         var ipAddress = $(this).val();
         ipAddress = ipAddress.split('/')[0];
-        var unique = $.inArray(ipAddress, ipList) == -1;
-        if (unique) {
-            ipList.push(ipAddress);
+        if (ipAddress.length > 0) {
+            var unique = $.inArray(ipAddress, ipList) == -1;
+            if (unique) {
+                ipList.push(ipAddress);
+            }
         }
     });
 


### PR DESCRIPTION
Just a small fix for preventing extra blank IP address lines from appearing on the topology input.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion-web/50)
<!-- Reviewable:end -->
