### PR TITLE
Clear selected linktype

### DIFF
--- a/ad_manager/static/js/topology_input.js
+++ b/ad_manager/static/js/topology_input.js
@@ -252,9 +252,10 @@ function reloadRouterInterfaceSection(interface_obj, itemSelector) {
                 // we need to test if the AS is core, so that in case the link type is routing, the option gets added
                 checkShowCoreOption();
                 // remove all previous selected options for this select
-                $(linkType).find("option").removeProp("selected");
+                $(linkType).find("option").removeAttr('selected');
                 // set selected option
-                $(linkType).find('option[value="' + value + '"]').attr('selected', 'selected');
+                $(linkType).find('option[value="' + value + '"]').attr('selected', 'selected'); // in HTML for form submission
+                $(linkType).find('option[value="' + value + '"]').prop('selected', 'selected'); // in DOM for displaying
                 break;
             case 'MTU':
                 $(itemSelector + '#inputLinkMTU').attr('value', value);


### PR DESCRIPTION
Fix link type reloading
removeProp should not be used here: 'removeProp: Do not use this method to remove native properties such as checked, disabled, or selected. This will remove the property completely and, once removed, cannot be added again to element'

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion-web/53)
<!-- Reviewable:end -->
