### PR TITLE
Remove ForeignKey requirement of the neighbor AS from RouterWeb.

### DIFF
--- a/ad_manager/admin.py
+++ b/ad_manager/admin.py
@@ -116,17 +116,17 @@ class ServerAdmin(PrivilegedChangeAdmin):
 
 @admin.register(RouterWeb, site=admin_site)
 class RouterAdmin(ServerAdmin):
-    list_display = ('ad', 'addr', 'neighbor_ad', 'neighbor_type',
-                    'interface_addr', 'interface_toaddr')
+    list_display = ('ad', 'addr', 'neighbor_isd_id', 'neighbor_as_id',
+                    'neighbor_type', 'interface_addr', 'interface_toaddr')
 
     def get_fields(self, request, obj=None):
         # FIXME is there a way to make it more explicit?
-        self.raw_id_fields += ('neighbor_ad',)
+        self.raw_id_fields += ('neighbor_isd_id', 'neighbor_as_id')
         fields = super().get_fields(request, obj)
         fields += ('interface_id',
                    ('interface_addr', 'interface_port'),
                    ('interface_toaddr', 'interface_toport'),
-                   ('neighbor_ad', 'neighbor_type'))
+                   ('neighbor_isd_id', 'neighbor_as_id', 'neighbor_type'))
         return fields
 
 

--- a/ad_manager/migrations/0045_routerweb_remove_foreignkey_20170313_1439.py
+++ b/ad_manager/migrations/0045_routerweb_remove_foreignkey_20170313_1439.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+def copy_data(apps, schema_editor):
+    model_obj = apps.get_model("ad_manager", "RouterWeb")
+    for router in model_obj.objects.all():
+        router.neighbor_isd_id = router.neighbor_ad.isd_id
+        router.neighbor_as_id = router.neighbor_ad.as_id
+        router.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('ad_manager', '0044_auto_20170302_1940'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='routerweb',
+            name='neighbor_as_id',
+            field=models.IntegerField(null=True),
+        ),
+        migrations.AddField(
+            model_name='routerweb',
+            name='neighbor_isd_id',
+            field=models.IntegerField(null=True),
+        ),
+        migrations.RunPython(copy_data),
+        migrations.RemoveField(
+            model_name='routerweb',
+            name='neighbor_ad',
+        ),
+    ]

--- a/ad_manager/templates/ad_manager/network_view.html
+++ b/ad_manager/templates/ad_manager/network_view.html
@@ -25,8 +25,8 @@
 {% block content %}
 
   <h2>
-    {% if pov_ad %}
-      Network graph for <a href="{{ pov_ad.get_absolute_url }}">AS {{ pov_ad }}</a>
+    {% if pov_as %}
+      Network graph for <a href="{{ pov_as.get_absolute_url }}">AS {{ pov_as }}</a>
     {% else %}
       Full network graph
     {% endif %}

--- a/ad_manager/templates/ad_manager/partials/object_path.html
+++ b/ad_manager/templates/ad_manager/partials/object_path.html
@@ -11,7 +11,7 @@ This element is also called 'Breadcrumbs': http://en.wikipedia.org/wiki/Breadcru
   <span class="glyphicon glyphicon-menu-right"></span>
   AS {{ object.as_id }}
   <!-- Mind map icon -->
-  <a href="{% url 'network_view_ad' object.as_id %}">
+  <a href="{% url 'network_view_as' isd_id=object.isd_id as_id=object.as_id %}">
     <img src="{% static 'img/mind_map.png' %}" width="24">
   </a>
 </h1>

--- a/ad_manager/templates/ad_manager/partials/router_table.html
+++ b/ad_manager/templates/ad_manager/partials/router_table.html
@@ -12,14 +12,12 @@
   </thead>
   <tbody>
   {% for router in routers %}
-    <tr id="{{ router.id_str }}">
+    <tr id="{{ router.name }}">
       <td>Router {{ router.name }}</td>
       <td class="text-center">{{ router.addr }}</td>
       <td class="text-center">{{ router.interface_addr }}</td>
       <td class="text-center">{{ router.interface_toaddr }}</td>
-      <td class="text-center">
-        <a href="{{ router.neighbor_ad.get_absolute_url }}">{{ router.neighbor_ad }}</a>
-      </td>
+      <td class="text-center">{{ router.neighbor_isd_id }}-{{ router.neighbor_as_id }}</td>
       <td>{{ router.neighbor_type }}</td>
     </tr>
   {% empty %}

--- a/ad_manager/tests/test_acceptance.py
+++ b/ad_manager/tests/test_acceptance.py
@@ -132,13 +132,9 @@ class TestAdDetail(BasicWebTest):
         router_rows = routers.find_all('tr')[1:]
         for r in ad.routerweb_set.all():
             row = next(filter(lambda x: r.addr in x.text, router_rows))
-            assert str(r.neighbor_ad) in row.text
+            assert str(r.neighbor_isd_id) in row.text
+            assert str(r.neighbor_as_id) in row.text
             assert r.neighbor_type in row.text
-
-        # Test that links to other ASes work
-        ad_2_detail = ad_detail.click(str(self.ads[2]))
-        self.assertEqual(ad_2_detail.status_int, 200)
-        self.assertContains(ad_2_detail, str(self.ads[2]))
 
     def test_labels(self):
         ad = self.ads[1]

--- a/ad_manager/tests/test_topology.json
+++ b/ad_manager/tests/test_topology.json
@@ -317,7 +317,8 @@
         "interface_port": 50000,
         "interface_addr": "127.0.0.18",
         "interface_toport": 50000,
-        "neighbor_ad": 3,
+        "neighbor_isd_id": 2,
+        "neighbor_as_id": 3,
         "interface_id": 1,
         "interface_toaddr": "127.0.0.2",
         "neighbor_type": "CORE"
@@ -334,7 +335,8 @@
         "interface_port": 50000,
         "interface_addr": "127.0.0.20",
         "interface_toport": 50000,
-        "neighbor_ad": 2,
+        "neighbor_isd_id": 1,
+        "neighbor_as_id": 2,
         "interface_id": 2,
         "interface_toaddr": "127.0.0.40",
         "neighbor_type": "CHILD"
@@ -351,7 +353,8 @@
         "interface_port": 50000,
         "interface_addr": "127.0.0.40",
         "interface_toport": 50000,
-        "neighbor_ad": 1,
+        "neighbor_isd_id": 1,
+        "neighbor_as_id": 1,
         "interface_id": 1,
         "interface_toaddr": "127.0.0.20",
         "neighbor_type": "PARENT"
@@ -368,7 +371,8 @@
         "interface_port": 50000,
         "interface_addr": "127.0.0.2",
         "interface_toport": 50000,
-        "neighbor_ad": 1,
+        "neighbor_isd_id": 1,
+        "neighbor_as_id": 1,
         "interface_id": 1,
         "interface_toaddr": "127.0.0.18",
         "neighbor_type": "CORE"
@@ -385,7 +389,8 @@
         "interface_port": 50000,
         "interface_addr": "127.0.0.8",
         "interface_toport": 50000,
-        "neighbor_ad": 5,
+        "neighbor_isd_id": 2,
+        "neighbor_as_id": 5,
         "interface_id": 4,
         "interface_toaddr": "127.0.0.34",
         "neighbor_type": "CHILD"
@@ -402,7 +407,8 @@
         "interface_port": 50000,
         "interface_addr": "127.0.0.4",
         "interface_toport": 50000,
-        "neighbor_ad": 4,
+        "neighbor_isd_id": 2,
+        "neighbor_as_id": 4,
         "interface_id": 2,
         "interface_toaddr": "127.0.0.28",
         "neighbor_type": "CHILD"
@@ -419,7 +425,8 @@
         "interface_port": 50000,
         "interface_addr": "127.0.0.6",
         "interface_toport": 50000,
-        "neighbor_ad": 6,
+        "neighbor_isd_id": 10,
+        "neighbor_as_id": 6,
         "interface_id": 3,
         "interface_toaddr": "127.0.0.12",
         "neighbor_type": "CORE"
@@ -436,7 +443,8 @@
         "interface_port": 50000,
         "interface_addr": "127.0.0.28",
         "interface_toport": 50000,
-        "neighbor_ad": 3,
+        "neighbor_isd_id": 2,
+        "neighbor_as_id": 3,
         "interface_id": 1,
         "interface_toaddr": "127.0.0.4",
         "neighbor_type": "PARENT"
@@ -453,7 +461,8 @@
         "interface_port": 50000,
         "interface_addr": "127.0.0.30",
         "interface_toport": 50000,
-        "neighbor_ad": 5,
+        "neighbor_isd_id": 2,
+        "neighbor_as_id": 5,
         "interface_id": 2,
         "interface_toaddr": "127.0.0.36",
         "neighbor_type": "CORE"
@@ -470,7 +479,8 @@
         "interface_port": 50000,
         "interface_addr": "127.0.0.34",
         "interface_toport": 50000,
-        "neighbor_ad": 3,
+        "neighbor_isd_id": 2,
+        "neighbor_as_id": 3,
         "interface_id": 1,
         "interface_toaddr": "127.0.0.8",
         "neighbor_type": "PARENT"
@@ -487,7 +497,8 @@
         "interface_port": 50000,
         "interface_addr": "127.0.0.36",
         "interface_toport": 50000,
-        "neighbor_ad": 4,
+        "neighbor_isd_id": 2,
+        "neighbor_as_id": 4,
         "interface_id": 2,
         "interface_toaddr": "127.0.0.30",
         "neighbor_type": "CORE"
@@ -504,7 +515,8 @@
         "interface_port": 50000,
         "interface_addr": "127.0.0.12",
         "interface_toport": 50000,
-        "neighbor_ad": 3,
+        "neighbor_isd_id": 2,
+        "neighbor_as_id": 3,
         "interface_id": 1,
         "interface_toaddr": "127.0.0.6",
         "neighbor_type": "CORE"
@@ -521,7 +533,8 @@
         "interface_port": 50000,
         "interface_addr": "127.0.0.14",
         "interface_toport": 50000,
-        "neighbor_ad": 7,
+        "neighbor_isd_id": 10,
+        "neighbor_as_id": 7,
         "interface_id": 2,
         "interface_toaddr": "127.0.0.24",
         "neighbor_type": "CHILD"
@@ -538,7 +551,8 @@
         "interface_port": 50000,
         "interface_addr": "127.0.0.24",
         "interface_toport": 50000,
-        "neighbor_ad": 6,
+        "neighbor_isd_id": 10,
+        "neighbor_as_id": 6,
         "interface_id": 1,
         "interface_toaddr": "127.0.0.14",
         "neighbor_type": "PARENT"

--- a/ad_manager/tests/test_util.py
+++ b/ad_manager/tests/test_util.py
@@ -53,8 +53,10 @@ class TestLinkAds(TestCase):
             router1 = ad1.routerweb_set.all()[0]
             router2 = ad2.routerweb_set.all()[0]
 
-            assert router1.neighbor_ad == ad2
-            assert router2.neighbor_ad == ad1
+            assert router1.neighbor_isd_id == ad2.isd.id
+            assert router1.neighbor_as_id == ad2.as_id
+            assert router2.neighbor_isd_id == ad1.isd.id
+            assert router2.neighbor_as_id == ad1.as_id
 
             # Check addresses
             assert router1.interface_toaddr == router2.interface_addr

--- a/ad_manager/urls.py
+++ b/ad_manager/urls.py
@@ -92,8 +92,8 @@ misc = patterns(
     '',
     url(r'^network/?$',
         views.network_view, name='network_view'),
-    url(r'^network/(?P<pk>\d+)/?$',
-        views.network_view_neighbors, name='network_view_ad'),
+    url(r'^network/isd/(?P<isd_id>\d+)/as/(?P<as_id>\d+)/?$',
+        views.network_view_neighbors, name='network_view_as'),
     url(r'^coord_service/?$',
         views.coord_service, name='coord_service'),
 )


### PR DESCRIPTION
@FR4NK-W It would be great if you could take a look at this PR.
@kormat , @klausman If you find the time, it would be great if one you could have a look at this as well (at least the Python code)

- This PR Fixes https://github.com/netsec-ethz/scion-web/issues/65
- It removes the ForeignKey requirement of the neighbor AS from RouterWeb model
since local scion-web instances in the testbed will not have the neighbor ASes in their
local databases in most cases. Instead, the neighbor AS is represented with its ISD and
AS IDs.
- Adapts the existing network view (visualization) tab: If the neighboring AS is not in
the local scion-web database, then it is not shown in the network view. Only the network
view of the ASes that are known to the local scion-web instance are shown.
- Adapts the tests accordingly.
- Where applicable, renames 'ad' to 'as' in the variables used.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion-web/69)
<!-- Reviewable:end -->
